### PR TITLE
Feat/some tunings

### DIFF
--- a/src/.github/workflows/lint.yml
+++ b/src/.github/workflows/lint.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Check for new NPM dependencies
         uses: hiwelo/new-dependencies-action@1.0.1
         with:
-          token: ${{ secrets.OKP4_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   lint-branch-name:
     runs-on: ubuntu-20.04

--- a/src/.github/workflows/lint.yml
+++ b/src/.github/workflows/lint.yml
@@ -80,13 +80,6 @@ jobs:
       - name: Lint dockerfile (hadolint)
         uses: hadolint/hadolint-action@v2.1.0
 
-      - name: Lint dockerfile (docker-lint)
-        uses: luke142367/Docker-Lint-Action@v1.1.1
-        with:
-          target: Dockerfile
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   lint-go:
     runs-on: ubuntu-20.04
     steps:

--- a/src/.github/workflows/publish.yml
+++ b/src/.github/workflows/publish.yml
@@ -55,28 +55,31 @@ jobs:
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
 
-  publish-npm-package-okp4:
+  publish-npm-package:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        registry:
+          - url: "https://npm.pkg.github.com"
+            auth-token-secret: NPM_REGISTRY_TOKEN
+          - url: "https://registry.npmjs.org"
+            auth-token-secret: NPM_PUBLIC_REGISTRY_TOKEN
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-
-      - name: Set up context
-        id: project_context
-        uses: FranzDiebold/github-env-vars-action@v2.3.1
 
       - name: Setup node environment (for publishing)
         uses: actions/setup-node@v3
         with:
           node-version: 16.14.0
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: ${{ matrix.registry.url }}
           scope: "@okp4"
 
       - name: Publish package
         run: |
-          DATE=$(date +%Y%m%d%H%M%S)
           yarn && yarn build
-          publish=(yarn publish --no-git-tag-version --non-interactive)
+          DATE=$(date +%Y%m%d%H%M%S)
+          publish=(yarn publish --access=public --no-git-tag-version --non-interactive)
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             publish+=(--tag latest)
           else
@@ -85,35 +88,7 @@ jobs:
           echo "🚀 Publishing npm package with following command line: ${publish[@]}"
           "${publish[@]}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-
-  publish-npm-package-public:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Set up context
-        id: project_context
-        uses: FranzDiebold/github-env-vars-action@v2.3.1
-
-      - name: Setup node environment (for publishing)
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.14.0
-          registry-url: "https://registry.npmjs.org"
-          scope: "@okp4"
-
-      - name: Publish package
-        run: |
-          yarn && yarn build
-          publish=(yarn publish --access=public --no-git-tag-version --non-interactive)
-          publish+=(--tag latest)
-          echo "🚀 Publishing npm package with following command line: ${publish[@]}"
-          "${publish[@]}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLIC_REGISTRY_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets[matrix.registry.auth-token-secret] }}
 
   publish-storybook:
     timeout-minutes: 10

--- a/src/.github/workflows/publish.yml
+++ b/src/.github/workflows/publish.yml
@@ -121,7 +121,7 @@ jobs:
             feat: update storybook site (auto)
 
   publish-pypi:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository


### PR DESCRIPTION
Improve some existing flows:

## Publish

Now publish npm `next` versions to public registry.

The logic being identical with Github Package publication, the two jobs has been merged and refactored using matrix strategy.

## Lint

Mainly for PR from forks purposes:
- `report-new-dependencies`: Change Github token used to comment PRs.
- `lint-docker`: Remove `dockerlint` action, by annotating PR changes it needs a token with repository access which we can't ensure from forks. Being less strict than `hadolint` I think removing it is rational.