### PR TITLE
ci(lint): skip commit lint for dependabot

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   lint-commits:
     runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Self explanatory..

Disturbing for an action's collection 👀 