### PR TITLE
Add a markdown link lint job

### DIFF
--- a/resources/.mlc_config.json
+++ b/resources/.mlc_config.json
@@ -1,0 +1,7 @@
+{
+    "timeout": "20s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206]
+}

--- a/src/.github/workflows/lint.yml
+++ b/src/.github/workflows/lint.yml
@@ -38,6 +38,20 @@ jobs:
           args: "**/*.md"
           ignore: "CHANGELOG.md"
 
+  lint-markdown-link:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Lint markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          base-branch: "main"
+          config-file: ".mlc_config.json"
+
   lint-yaml:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Reference a linter to will check that URLs mentioned in a markdown file are alive.