### PR TITLE
ci(workflow): fix fetch depth checkout (lint-go)

### DIFF
--- a/src/.github/workflows/lint.yml
+++ b/src/.github/workflows/lint.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Lint json files
         run: |


### PR DESCRIPTION
Fixes following issue during `lint-go` job:

```
 From https://github.com/okp4/xxxxx
   * [new branch]      main       -> main
   * [new branch]      main       -> origin/main
  Error: Unable to locate the previous sha: 89adde974477091a09b0553ea13fa3005ec84bfb
  Error: You seem to be missing 'fetch-depth: 0' or 'fetch-depth: 2'. See https://github.com/tj-actions/changed-files#usage
  Error: Process completed with exit code 1.
```