### PR TITLE
fix: specify concrete version of Shellcheck to be used

### DIFF
--- a/src/.github/workflows/lint.yml
+++ b/src/.github/workflows/lint.yml
@@ -339,6 +339,7 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         with:
           scandir: "./shell"
+          version: "v0.8.0"
 
   lint-cargo-toml:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Minor. Specify a [concrete version](https://github.com/ludeeus/action-shellcheck#run-a-specific-version-of-shellcheck) of [Shellcheck](https://github.com/koalaman/shellcheck) to be used.