### PR TITLE
⬆️ Update github action runners to ubuntu-22.04

### DIFF
--- a/src/.github/workflows/export-drawio.yml
+++ b/src/.github/workflows/export-drawio.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   drawio-export:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Bumps github runners to [ubuntu-22.04](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).
